### PR TITLE
Added named parameters for me.topArtists & me.topTracks endpoints (following #137)

### DIFF
--- a/lib/src/endpoints/me.dart
+++ b/lib/src/endpoints/me.dart
@@ -67,38 +67,49 @@ class Me extends EndpointPaging {
 
   /// Get tracks from the current user’s recently played tracks.
   /// Note: Currently doesn’t support podcast episodes.
-  CursorPages<PlayHistory> recentlyPlayed({int? limit, DateTime? after, DateTime? before}) {
+  CursorPages<PlayHistory> recentlyPlayed(
+      {int? limit, DateTime? after, DateTime? before}) {
     assert(after == null || before == null,
-      'Cannot specify both after and before.');
+        'Cannot specify both after and before.');
 
-    return _getCursorPages('$_path/player/recently-played?' +
-        _buildQuery({
-          'limit': limit,
-          'after': after?.millisecondsSinceEpoch,
-          'before': before?.millisecondsSinceEpoch
-        }), (json) => PlayHistory.fromJson(json));
+    return _getCursorPages(
+        '$_path/player/recently-played?' +
+            _buildQuery({
+              'limit': limit,
+              'after': after?.millisecondsSinceEpoch,
+              'before': before?.millisecondsSinceEpoch
+            }),
+        (json) => PlayHistory.fromJson(json));
   }
 
   /// Get the current user's top tracks.
-  /// @param limit: the maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.
-  /// @param offset: The index of the first item to return. Default: 0 (the first item). Use with limit to get the next set of items.
-  /// @param time_range: Over what time frame the affinities are computed (long_term, medium_term, short_term)
-  /// For more information, see https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-top-artists-and-tracks
-  Future<Iterable<Track>> topTracks(int limit, int offset, String timeRange) async {
-    final jsonString = await _api._get('$_path/top/tracks?time_range=$timeRange&limit=$limit&offset=$offset');
+  /// [limit] - the maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.\
+  /// [offset] - The index of the first item to return. Default: 0 (the first item). Use with limit to get the next set of items.\
+  /// [timeRange] - Over what time frame the affinities are computed (long_term, medium_term, short_term)\
+  /// For more information See https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-top-artists-and-tracks
+  Future<Iterable<Track>> topTracks(
+      {int limit = 20,
+      int offset = 0,
+      String timeRange = 'medium_term'}) async {
+    final jsonString = await _api._get(
+        '$_path/top/tracks?time_range=$timeRange&limit=$limit&offset=$offset');
     final map = json.decode(jsonString);
 
     final items = map['items'] as Iterable<dynamic>;
     return items.map((item) => Track.fromJson(item));
   }
 
-  /// Get the current user's top artists.
-  /// @param limit: the maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.
-  /// @param offset: The index of the first item to return. Default: 0 (the first item). Use with limit to get the next set of items.
-  /// @param time_range: Over what time frame the affinities are computed (long_term, medium_term, short_term)
+  /// Get the current user's top artists.\
+  /// [limit] - the maximum number of items to return. Default: 20. Minimum: 1. Maximum: 50.\
+  /// [offset] - The index of the first item to return. Default: 0 (the first item). Use with limit to get the next set of items.\
+  /// [timeRange] - Over what time frame the affinities are computed (long_term, medium_term, short_term)\
   /// For more information See https://developer.spotify.com/documentation/web-api/reference/#/operations/get-users-top-artists-and-tracks
-  Future<Iterable<Artist>> topArtists(int limit, int offset, String timeRange) async {
-    final jsonString = await _api._get('$_path/top/artists?time_range=$timeRange&limit=$limit&offset=$offset');
+  Future<Iterable<Artist>> topArtists(
+      {int limit = 20,
+      int offset = 0,
+      String timeRange = 'medium_term'}) async {
+    final jsonString = await _api._get(
+        '$_path/top/artists?time_range=$timeRange&limit=$limit&offset=$offset');
     final map = json.decode(jsonString);
 
     final items = map['items'] as Iterable<dynamic>;

--- a/lib/src/endpoints/users.dart
+++ b/lib/src/endpoints/users.dart
@@ -23,7 +23,7 @@ class Users extends EndpointPaging {
   CursorPages<PlayHistory> recentlyPlayed() => _me.recentlyPlayed();
 
   @Deprecated('Use "SpotifyApi.me.topTracks()"')
-  Future<Iterable<Track>> topTracks() => _me.topTracks(20, 0, "medium_term");
+  Future<Iterable<Track>> topTracks() => _me.topTracks();
 
   @Deprecated('Use "SpotifyApi.me.devices()"')
   Future<Iterable<Device>> devices() async => _me.devices();


### PR DESCRIPTION
PR #137 modified me.topArtists & me.TopTracks endpoints to accept 3 parameters, including: ""limit", "offset", & "time_range".

However, past users might have left them blank. The example includes the modified deprecated `users.topTracks()` where the parameters in `me.topTracks()` were left blank.

Hence, I modified them to be named parameters with default values.